### PR TITLE
Update Native SDK 2.17.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: Aggregit
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  recordMetrics:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: michaeljolley/aggregit@v1.3
+      with:
+        githubToken: ${{ secrets.GITHUB_TOKEN }}
+        project_id: ${{ secrets.project_id }}
+        private_key: ${{ secrets.private_key }}
+        client_email: ${{ secrets.client_email }}
+        firebaseDbUrl: ${{ secrets.firebaseDbUrl }}

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -8,7 +8,7 @@ jobs:
   recordMetrics:
     runs-on: ubuntu-latest
     steps:
-    - uses: michaeljolley/aggregit@v1.3
+    - uses: michaeljolley/aggregit@v1
       with:
         githubToken: ${{ secrets.GITHUB_TOKEN }}
         project_id: ${{ secrets.project_id }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.13.0 (Mar 23, 2020)
+
+- **[Feature]**: Add Session Options support, both [iOS](https://tokbox.com/developer/sdks/ios/reference/Classes/OTSessionSettings.html) and [Android](https://tokbox.com/developer/sdks/android/reference/). Note: iceConfig option is not currently supported
+- **[Feature]**: Update of iOS SDK to `2.16.5` and Android SDK to `2.16.5`
+
 
 # 0.12.2 (Dec 4, 2019)
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+devrel@vonage.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,27 +2,27 @@
 
 If you're interested in contributing to this project, here are a few ways to do so:
 
-*  Bug fixes
-    -  If you find a bug, please first report it using Github Issues.
-    -  Issues that have already been identified as a bug will be labelled `bug`.
-    -  If you'd like to submit a fix for a bug, send a Pull Request from your own fork and mention the Issue number.
-        +  Include a test that isolates the bug and verifies that it was fixed.
-*  New Features
-    -  If you'd like to add a feature to the library that doesn't already exist, feel free to describe the feature in a new Github Issue.
-    -  Issues that have been identified as a feature request will be labelled `enhancement`.
-    -  If you'd like to implement the new feature, please wait for feedback from the project maintainers before spending too much time writing the code. In some cases, `enhancement`s may not align well with the project objectives at the time.
-*  Documentation & Miscellaneous
-    -  If you think the documentation could be clearer, or you have an alternative
-       implementation of something that may have more advantages, we would love to hear it.
-       -  If its a trivial change, go ahead and send a Pull Request with the changes you have in mind
-       -  If not, open a Github Issue to discuss the idea first.
+- Bug fixes
+  - If you find a bug, please first report it using Github Issues.
+  - Issues that have already been identified as a bug will be labelled `bug`.
+  - If you'd like to submit a fix for a bug, send a Pull Request from your own fork and mention the Issue number.
+    - Include a test that isolates the bug and verifies that it was fixed.
+- New Features
+  - If you'd like to add a feature to the library that doesn't already exist, feel free to describe the feature in a new Github Issue.
+  - Issues that have been identified as a feature request will be labelled `enhancement`.
+  - If you'd like to implement the new feature, please wait for feedback from the project maintainers before spending too much time writing the code. In some cases, `enhancement`s may not align well with the project objectives at the time.
+- Documentation & Miscellaneous
+  - If you think the documentation could be clearer, or you have an alternative
+    implementation of something that may have more advantages, we would love to hear it.
+    - If its a trivial change, go ahead and send a Pull Request with the changes you have in mind
+    - If not, open a Github Issue to discuss the idea first.
 
 ## Requirements
 
 For a contribution to be accepted:
 
-*  Code must follow existing styling conventions
-*  Commit messages must be descriptive. Related issues should be mentioned by number.
+- Code must follow existing styling conventions
+- Commit messages must be descriptive. Related issues should be mentioned by number.
 
 If the contribution doesn't meet these criteria, a maintainer will discuss it with you on the Issue. You can still continue to add more commits to the branch you have sent the Pull Request from.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # opentok-react-native
-![OpenTok Labs](https://d26dzxoao6i3hh.cloudfront.net/items/0U1R0a0e2g1E361H0x3c/Image%202017-11-22%20at%2012.16.38%20PM.png?v=2507a2df)
+
+<img src="https://assets.tokbox.com/img/vonage/Vonage_VideoAPI_black.svg" height="48px" alt="Tokbox is now known as Vonage" />
 
 React Native library for OpenTok iOS and Android SDKs
 
@@ -22,23 +23,27 @@ React Native library for OpenTok iOS and Android SDKs
 1. Install [node.js](https://nodejs.org/)
 
 2. Install and update [Xcode](https://developer.apple.com/xcode/) (you will need a Mac)
-* React Native iOS installation [instructions](https://facebook.github.io/react-native/docs/getting-started.html)
+
+- React Native iOS installation [instructions](https://facebook.github.io/react-native/docs/getting-started.html)
 
 3. Install and update [Android Studio](https://developer.android.com/studio/index.html)
-* React Native Android installation [instructions](https://facebook.github.io/react-native/docs/getting-started.html)
+
+- React Native Android installation [instructions](https://facebook.github.io/react-native/docs/getting-started.html)
 
 ## Installation:
 
 1. In your terminal, change into your React Native project's directory
 
 2. Add the library using `npm` or `yarn`.
-* `npm install opentok-react-native`
-* `yarn add opentok-react-native`
+
+- `npm install opentok-react-native`
+- `yarn add opentok-react-native`
 
 ### iOS Installation
 
 **Note:** Please make sure to have [CocoaPods](https://cocoapods.org/) on your computer.
 If you've installed this package before, you may need to edit your `Podfile` and project structure because the installation process has changed.
+
 1. In you terminal, change into the `ios` directory of your React Native project.
 
 2. Create a pod file by running: `pod init`.
@@ -65,7 +70,8 @@ If you've installed this package before, you may need to edit your `Podfile` and
 6. Click `File` and `New File`
 
 7. Add an empty swift file to your project:
-    * You can name this file anything i.e: `OTInstall.swift`. This is done to set some flags in XCode so the Swift code can be used.
+
+   - You can name this file anything i.e: `OTInstall.swift`. This is done to set some flags in XCode so the Swift code can be used.
 
 8. Click `Create Bridging Header` when you're prompted with the following modal: `Would you like to configure an Objective-C bridging header?`
 
@@ -89,7 +95,8 @@ If you try to archive the app and it fails, please do the following:
 1. In your terminal, change into your project directory.
 
 2. If you have already run `react-native link opentok-react-native` for the iOS installation, please skip this step.
-    *  Run `react-native link opentok-react-native`
+
+   - Run `react-native link opentok-react-native`
 
 3. Open your Android project in Android Studio.
 
@@ -122,6 +129,16 @@ Newer versions of Android–`API Level 23` (Android 6.0)–have a different perm
 
 To see this library in action, check out the [opentok-react-native-samples](https://github.com/opentok/opentok-react-native-samples) repo.
 
-## Contributing
+## Development and Contributing
 
-If you make changes to the project that you would like to contribute back then please follow the [contributing guidelines](CONTRIBUTING.md). All contributions are greatly appreciated!
+Interested in contributing? We :heart: pull requests! See the
+[Contribution](CONTRIBUTING.md) guidelines.
+
+## Getting Help
+
+We love to hear from you so if you have questions, comments or find a bug in the project, let us know! You can either:
+
+- Open an issue on this repository
+- See <https://support.tokbox.com/> for support options
+- Tweet at us! We're [@VonageDev](https://twitter.com/VonageDev) on Twitter
+- Or [join the Vonage Developer Community Slack](https://developer.nexmo.com/community/slack)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,5 +22,5 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:${_reactNativeVersion}"  // From node_modules
-    implementation 'com.opentok.android:opentok-android-sdk:2.16.3'
+    implementation 'com.opentok.android:opentok-android-sdk:2.16.5'
 }

--- a/android/src/main/java/com/opentokreactnative/OTSessionManager.java
+++ b/android/src/main/java/com/opentokreactnative/OTSessionManager.java
@@ -34,6 +34,7 @@ import com.opentokreactnative.utils.Utils;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.ArrayList;
+import java.util.List;
 
 public class OTSessionManager extends ReactContextBaseJavaModule
         implements Session.SessionListener,
@@ -73,6 +74,12 @@ public class OTSessionManager extends ReactContextBaseJavaModule
         final boolean useTextureViews = sessionOptions.getBoolean("useTextureViews");
         final boolean isCamera2Capable = sessionOptions.getBoolean("isCamera2Capable");
         final boolean connectionEventsSuppressed = sessionOptions.getBoolean("connectionEventsSuppressed");
+        final boolean ipWhitelist = sessionOptions.getBoolean("ipWhitelist");
+        // Note: IceConfig is an additional property not supported at the moment. 
+        // final ReadableMap iceConfig = sessionOptions.getMap("iceConfig");
+        // final List<Session.Builder.IceServer> iceConfigServerList = (List<Session.Builder.IceServer>) iceConfig.getArray("customServers");
+        // final Session.Builder.IncludeServers iceConfigServerConfig; // = iceConfig.getString("includeServers");
+        final String proxyUrl = sessionOptions.getString("proxyUrl");
         String androidOnTop = sessionOptions.getString("androidOnTop");
         String androidZOrder = sessionOptions.getString("androidZOrder");
         ConcurrentHashMap<String, Session> mSessions = sharedState.getSessions();
@@ -93,6 +100,10 @@ public class OTSessionManager extends ReactContextBaseJavaModule
                     }
                 })
                 .connectionEventsSuppressed(connectionEventsSuppressed)
+                // Note: setCustomIceServers is an additional property not supported at the moment. 
+                // .setCustomIceServers(serverList, config)
+                .setIpWhitelist(ipWhitelist)
+                .setProxyUrl(proxyUrl)
                 .build();
         mSession.setSessionListener(this);
         mSession.setSignalListener(this);

--- a/android/src/main/java/com/opentokreactnative/utils/EventUtils.java
+++ b/android/src/main/java/com/opentokreactnative/utils/EventUtils.java
@@ -21,7 +21,7 @@ public final class EventUtils {
         return connectionInfo;
     }
 
-    public static WritableMap prepareJSStreamMap(Stream stream) {
+    public static WritableMap prepareJSStreamMap(Stream stream, Session session) {
 
         WritableMap streamInfo = Arguments.createMap();
         if (stream != null) {
@@ -30,7 +30,7 @@ public final class EventUtils {
             streamInfo.putInt("width", stream.getVideoWidth());
             streamInfo.putString("creationTime", stream.getCreationTime().toString());
             streamInfo.putString("connectionId", stream.getConnection().getConnectionId());
-            streamInfo.putString("sessionId", stream.getSession().getSessionId());
+            streamInfo.putString("sessionId", session.getSessionId());
             streamInfo.putMap("connection", prepareJSConnectionMap(stream.getConnection()));
             streamInfo.putString("name", stream.getName());
             streamInfo.putBoolean("hasAudio", stream.hasAudio());
@@ -63,33 +63,33 @@ public final class EventUtils {
         return sessionInfo;
     }
 
-    public static WritableMap prepareStreamPropertyChangedEventData(String changedProperty, String oldValue, String newValue, Stream stream) {
+    public static WritableMap prepareStreamPropertyChangedEventData(String changedProperty, String oldValue, String newValue, Stream stream, Session session) {
 
         WritableMap streamPropertyEventData = Arguments.createMap();
         streamPropertyEventData.putString("changedProperty", changedProperty);
         streamPropertyEventData.putString("oldValue", oldValue);
         streamPropertyEventData.putString("newValue", newValue);
-        streamPropertyEventData.putMap("stream", prepareJSStreamMap(stream));
+        streamPropertyEventData.putMap("stream", prepareJSStreamMap(stream, session));
         return streamPropertyEventData;
     }
 
-    public static WritableMap prepareStreamPropertyChangedEventData(String changedProperty, WritableMap oldValue, WritableMap newValue, Stream stream) {
+    public static WritableMap prepareStreamPropertyChangedEventData(String changedProperty, WritableMap oldValue, WritableMap newValue, Stream stream, Session session) {
 
         WritableMap streamPropertyEventData = Arguments.createMap();
         streamPropertyEventData.putString("changedProperty", changedProperty);
         streamPropertyEventData.putMap("oldValue", oldValue);
         streamPropertyEventData.putMap("newValue", newValue);
-        streamPropertyEventData.putMap("stream", prepareJSStreamMap(stream));
+        streamPropertyEventData.putMap("stream", prepareJSStreamMap(stream, session));
         return streamPropertyEventData;
     }
 
-    public static WritableMap prepareStreamPropertyChangedEventData(String changedProperty, Boolean oldValue, Boolean newValue, Stream stream) {
+    public static WritableMap prepareStreamPropertyChangedEventData(String changedProperty, Boolean oldValue, Boolean newValue, Stream stream, Session session) {
 
         WritableMap streamPropertyEventData = Arguments.createMap();
         streamPropertyEventData.putString("changedProperty", changedProperty);
         streamPropertyEventData.putBoolean("oldValue", oldValue);
         streamPropertyEventData.putBoolean("newValue", newValue);
-        streamPropertyEventData.putMap("stream", prepareJSStreamMap(stream));
+        streamPropertyEventData.putMap("stream", prepareJSStreamMap(stream, session));
         return streamPropertyEventData;
     }
 

--- a/docs/OTSession.md
+++ b/docs/OTSession.md
@@ -97,6 +97,7 @@ class App extends Component {
       androidOnTop: '',  // Android only - valid options are 'publisher' or 'subscriber'
       useTextureViews: true,  // Android only - default is false
       isCamera2Capable: false, // Android only - default is false
+      ipWhitelist: false, // https://tokbox.com/developer/sdks/js/reference/OT.html#initSession - ipWhitelist
     };
   }
 

--- a/ios/OpenTokReactNative/OTSessionManager.m
+++ b/ios/OpenTokReactNative/OTSessionManager.m
@@ -31,6 +31,7 @@ RCT_EXTERN_METHOD(publish:
                   callback:(RCTResponseSenderBlock*)callback)
 RCT_EXTERN_METHOD(subscribeToStream:
                   (NSString*)streamId
+                  (NSString*)sessionId
                   properties:(NSDictionary*)properties
                   callback:(RCTResponseSenderBlock*)callback)
 RCT_EXTERN_METHOD(removeSubscriber:

--- a/ios/OpenTokReactNative/OTSessionManager.swift
+++ b/ios/OpenTokReactNative/OTSessionManager.swift
@@ -120,7 +120,7 @@ class OTSessionManager: RCTEventEmitter {
         }
     }
     
-    @objc func subscribeToStream(_ streamId: String, properties: Dictionary<String, Any>, callback: @escaping RCTResponseSenderBlock) -> Void {
+    @objc func subscribeToStream(_ streamId: String, sessionId: String, properties: Dictionary<String, Any>, callback: @escaping RCTResponseSenderBlock) -> Void {
         var error: OTError?
         DispatchQueue.main.async {
             guard let stream = OTRN.sharedState.subscriberStreams[streamId] else {
@@ -133,7 +133,7 @@ class OTSessionManager: RCTEventEmitter {
                 callback([errorInfo]);
                 return
             }
-            guard let session = OTRN.sharedState.sessions[stream.session.sessionId] else {
+            guard let session = OTRN.sharedState.sessions[sessionId] else {
                 let errorInfo = EventUtils.createErrorMessage("Error subscribing to stream. Could not find native session instance")
                 callback([errorInfo]);
                 return

--- a/ios/OpenTokReactNative/OTSessionManager.swift
+++ b/ios/OpenTokReactNative/OTSessionManager.swift
@@ -41,6 +41,11 @@ class OTSessionManager: RCTEventEmitter {
     @objc func initSession(_ apiKey: String, sessionId: String, sessionOptions: Dictionary<String, Any>) -> Void {
         let settings = OTSessionSettings()
         settings.connectionEventsSuppressed = Utils.sanitizeBooleanProperty(sessionOptions["connectionEventsSuppressed"] as Any);
+        // Note: IceConfig is an additional property not supported at the moment. We need to add a sanitize function
+        // to validate the input from settings.iceConfig.
+        // settings.iceConfig = sessionOptions["iceConfig"];
+        settings.proxyURL = Utils.sanitizeStringProperty(sessionOptions["proxyUrl"] as Any);
+        settings.ipWhitelist = Utils.sanitizeBooleanProperty(sessionOptions["ipWhitelist"] as Any);
         OTRN.sharedState.sessions.updateValue(OTSession(apiKey: apiKey, sessionId: sessionId, delegate: self, settings: settings)!, forKey: sessionId);
     }
     

--- a/ios/OpenTokReactNative/Utils/Utils.swift
+++ b/ios/OpenTokReactNative/Utils/Utils.swift
@@ -30,6 +30,11 @@ class Utils {
         guard let prop = property as? Bool else { return true; }
         return prop;
     }
+
+    static func sanitizeStringProperty(_ property: Any) -> String {
+        guard let prop = property as? String else { return ""; }
+        return prop;
+    }
     
     static func getPublisherId(_ publisher: OTPublisher) -> String {
         let publisherIds = OTRN.sharedState.publishers.filter {$0.value == publisher}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-react-native",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-react-native",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "React Native components for OpenTok iOS and Android SDKs",
   "main": "src/index.js",
   "homepage": "https://www.tokbox.com",

--- a/src/OTSession.js
+++ b/src/OTSession.js
@@ -31,7 +31,7 @@ export default class OTSession extends Component {
     const { apiKey, sessionId, token } = this.sanitizedCredentials;
     if (apiKey && sessionId && token) {
       this.createSession(this.sanitizedCredentials, sessionOptions);
-      logOT(this.sanitizedCredentials.apiKey, this.sanitizedCredentials.sessionId, 'rn_initialize');
+      logOT({ apiKey, sessionId, action: 'rn_initialize', proxyUrl: sessionOptions.proxyUrl });
     } else {
       handleError('Please check your OpenTok credentials.');
     }
@@ -70,7 +70,7 @@ export default class OTSession extends Component {
             this.setState({
               sessionInfo,
             });
-            logOT(apiKey, sessionId, 'rn_on_connect', session.connection.connectionId);
+            logOT({ apiKey, sessionId, action: 'rn_on_connect', proxyUrl: sessionOptions.proxyUrl, connectionId: session.connection.connectionId });
             if (Object.keys(signal).length > 0) {
               this.signal(signal);
             }

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -57,13 +57,13 @@ export default class OTSubscriber extends Component {
   streamCreatedHandler = (stream) => {
     const { subscribeToSelf } = this.state;
     const { streamProperties, properties } = this.props;
-    const { sessionInfo } = this.context;
+    const { sessionId, sessionInfo } = this.context;
     const subscriberProperties = isNull(streamProperties[stream.streamId]) ?
                                   sanitizeProperties(properties) : sanitizeProperties(streamProperties[stream.streamId]);
     // Subscribe to streams. If subscribeToSelf is true, subscribe also to his own stream
     const sessionInfoConnectionId = sessionInfo && sessionInfo.connection ? sessionInfo.connection.connectionId : null;
     if (subscribeToSelf || (sessionInfoConnectionId !== stream.connectionId)){
-      OT.subscribeToStream(stream.streamId, subscriberProperties, (error) => {
+      OT.subscribeToStream(stream.streamId, sessionId, subscriberProperties, (error) => {
         if (error) {
           this.otrnEventHandler(error);
         } else {

--- a/src/helpers/OTHelper.js
+++ b/src/helpers/OTHelper.js
@@ -11,9 +11,9 @@ const reassignEvents = (type, customEvents, events, eventKey) => {
   each(events, (eventHandler, eventType) => {
     if (customEvents[platform][eventType] !== undefined && eventKey !== undefined) {
       newEvents[`${eventKey}:${preface}${customEvents[platform][eventType]}`] = eventHandler;
-    } else if(customEvents[platform][eventType] !== undefined ) {    
+    } else if (customEvents[platform][eventType] !== undefined) {
       newEvents[`${preface}${customEvents[platform][eventType]}`] = eventHandler;
-    } else if(events['otrnError']) {
+    } else if (events['otrnError']) {
       // ignore otrnError event because it's for the js layer
     } else {
       handleError(`${eventType} is not a supported event`);
@@ -63,9 +63,11 @@ const getLog = (apiKey, sessionId, action, connectionId) => {
   return body;
 };
 
-const logRequest = (body) => {
+const logRequest = (body, proxyUrl) => {
+  const hlgUrl = 'hlg.tokbox.com/prod/logging/ClientEvent';
+  const url = proxyUrl ? `${proxyUrl}/${hlgUrl}` : `https://${hlgUrl}`;
   axios({
-    url: 'https://hlg.tokbox.com/prod/logging/ClientEvent',
+    url,
     method: 'post',
     data: JSON.stringify(body),
   })
@@ -77,8 +79,8 @@ const logRequest = (body) => {
     });
 };
 
-const logOT = (apiKey, sessionId, action, connectionId) => {
-  logRequest(getLog(apiKey, sessionId, action, connectionId));
+const logOT = ({ apiKey, sessionId, action, connectionId, proxyUrl }) => {
+  logRequest(getLog(apiKey, sessionId, action, connectionId), proxyUrl);
 };
 
 export {


### PR DESCRIPTION
Based on https://tokbox.com/developer/sdks/android/release-notes.html, I had to edit the subscribeToStream method to get sessionId as input from the React Component (as stream.getSession has been deprecated).

**Android:**
- edit EventUtils.js to accept Session object as input.
- subscribeToStream method: added sessionId as input from the React method
- OTPublisherView.java is failing because publisher.getSession has sessionId null. I am still investigating the issue, it could be a bug on the 2.17.0 SDK.

**iOS**:
- subscribeToStream method: added sessionId as input. Even if not needed, I thought it could be nice to have the same method signature between iOS and Android
- iOS needs testing

