### PR TITLE
Update SDK to 2.17.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.14.0 (May 22, 2020)
+
+- **[Feature]**: Update of iOS SDK to `2.17.0` and Android SDK to `2.17.1`
+
 # 0.13.0 (Mar 23, 2020)
 
 - **[Feature]**: Add Session Options support, both [iOS](https://tokbox.com/developer/sdks/ios/reference/Classes/OTSessionSettings.html) and [Android](https://tokbox.com/developer/sdks/android/reference/). Note: iceConfig option is not currently supported

--- a/README.md
+++ b/README.md
@@ -4,17 +4,15 @@
 
 React Native library for OpenTok iOS and Android SDKs
 
-- [Pre-Requisites](#pre-requisites)
-- [Installation](#installation)
-  - [iOS Installation](#ios-installation)
-  - [Android Installation](#android-installation)
-- API Reference
-  - [OTSession Component](https://github.com/opentok/opentok-react-native/tree/master/docs/OTSession.md)
-  - [OTPublisher Component](https://github.com/opentok/opentok-react-native/tree/master/docs/OTPublisher.md)
-  - [OTSubscriber Component](https://github.com/opentok/opentok-react-native/tree/master/docs/OTSubscriber.md)
-  - [Event Data](https://github.com/opentok/opentok-react-native/tree/master/docs/EventData.md)
-- [Samples](#samples)
-- [Contributing](#contributing)
+- [opentok-react-native](#opentok-react-native)
+    - [In this repo, you'll find the OpenTok React Native library:](#in-this-repo-youll-find-the-opentok-react-native-library)
+  - [Pre-Requisites:](#pre-requisites)
+  - [Installation:](#installation)
+    - [iOS Installation](#ios-installation)
+    - [Android Installation](#android-installation)
+  - [Samples](#samples)
+  - [Development and Contributing](#development-and-contributing)
+  - [Getting Help](#getting-help)
 
 ### In this repo, you'll find the OpenTok React Native library:
 
@@ -54,7 +52,7 @@ If you've installed this package before, you may need to edit your `Podfile` and
     target '<YourProjectName>' do
 
       # Pods for <YourProject>
-        pod 'OpenTok', '2.16.3'
+        pod 'OpenTok', '2.17.0'
     end
 
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,5 +22,5 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:${_reactNativeVersion}"  // From node_modules
-    implementation 'com.opentok.android:opentok-android-sdk:2.16.5'
+    implementation 'com.opentok.android:opentok-android-sdk:2.17.1'
 }

--- a/android/src/main/java/com/opentokreactnative/OTSessionManager.java
+++ b/android/src/main/java/com/opentokreactnative/OTSessionManager.java
@@ -388,7 +388,7 @@ public class OTSessionManager extends ReactContextBaseJavaModule
                 Publisher mPublisher = mPublishers.get(publisherId);
                 Session mSession = null;
                 mPublisherDestroyedCallbacks.put(publisherId, callback);
-                if (mPublisher != null && mPublisher.getSession() != null) {
+                if (mPublisher != null && mPublisher.getSession() != null && mPublisher.getSession().getSessionId() != null) {
                     mSession = mSessions.get(mPublisher.getSession().getSessionId());
                 }
 

--- a/android/src/main/java/com/opentokreactnative/OTSessionManager.java
+++ b/android/src/main/java/com/opentokreactnative/OTSessionManager.java
@@ -403,7 +403,6 @@ public class OTSessionManager extends ReactContextBaseJavaModule
                     mPublisher.getCapturer().stopCapture();
                 }
                 mPublishers.remove(publisherId);
-                callback.invoke();
             }
         });
     }

--- a/android/src/main/java/com/opentokreactnative/utils/EventUtils.java
+++ b/android/src/main/java/com/opentokreactnative/utils/EventUtils.java
@@ -21,7 +21,7 @@ public final class EventUtils {
         return connectionInfo;
     }
 
-    public static WritableMap prepareJSStreamMap(Stream stream) {
+    public static WritableMap prepareJSStreamMap(Stream stream, Session session) {
 
         WritableMap streamInfo = Arguments.createMap();
         if (stream != null) {
@@ -30,7 +30,7 @@ public final class EventUtils {
             streamInfo.putInt("width", stream.getVideoWidth());
             streamInfo.putString("creationTime", stream.getCreationTime().toString());
             streamInfo.putString("connectionId", stream.getConnection().getConnectionId());
-            streamInfo.putString("sessionId", stream.getSession().getSessionId());
+            streamInfo.putString("sessionId", session.getSessionId());
             streamInfo.putMap("connection", prepareJSConnectionMap(stream.getConnection()));
             streamInfo.putString("name", stream.getName());
             streamInfo.putBoolean("hasAudio", stream.hasAudio());
@@ -63,33 +63,33 @@ public final class EventUtils {
         return sessionInfo;
     }
 
-    public static WritableMap prepareStreamPropertyChangedEventData(String changedProperty, String oldValue, String newValue, Stream stream) {
+    public static WritableMap prepareStreamPropertyChangedEventData(String changedProperty, String oldValue, String newValue, Stream stream, Session session) {
 
         WritableMap streamPropertyEventData = Arguments.createMap();
         streamPropertyEventData.putString("changedProperty", changedProperty);
         streamPropertyEventData.putString("oldValue", oldValue);
         streamPropertyEventData.putString("newValue", newValue);
-        streamPropertyEventData.putMap("stream", prepareJSStreamMap(stream));
+        streamPropertyEventData.putMap("stream", prepareJSStreamMap(stream, session));
         return streamPropertyEventData;
     }
 
-    public static WritableMap prepareStreamPropertyChangedEventData(String changedProperty, WritableMap oldValue, WritableMap newValue, Stream stream) {
+    public static WritableMap prepareStreamPropertyChangedEventData(String changedProperty, WritableMap oldValue, WritableMap newValue, Stream stream, Session session) {
 
         WritableMap streamPropertyEventData = Arguments.createMap();
         streamPropertyEventData.putString("changedProperty", changedProperty);
         streamPropertyEventData.putMap("oldValue", oldValue);
         streamPropertyEventData.putMap("newValue", newValue);
-        streamPropertyEventData.putMap("stream", prepareJSStreamMap(stream));
+        streamPropertyEventData.putMap("stream", prepareJSStreamMap(stream, session));
         return streamPropertyEventData;
     }
 
-    public static WritableMap prepareStreamPropertyChangedEventData(String changedProperty, Boolean oldValue, Boolean newValue, Stream stream) {
+    public static WritableMap prepareStreamPropertyChangedEventData(String changedProperty, Boolean oldValue, Boolean newValue, Stream stream, Session session) {
 
         WritableMap streamPropertyEventData = Arguments.createMap();
         streamPropertyEventData.putString("changedProperty", changedProperty);
         streamPropertyEventData.putBoolean("oldValue", oldValue);
         streamPropertyEventData.putBoolean("newValue", newValue);
-        streamPropertyEventData.putMap("stream", prepareJSStreamMap(stream));
+        streamPropertyEventData.putMap("stream", prepareJSStreamMap(stream, session));
         return streamPropertyEventData;
     }
 

--- a/ios/OpenTokReactNative/OTSessionManager.m
+++ b/ios/OpenTokReactNative/OTSessionManager.m
@@ -31,6 +31,7 @@ RCT_EXTERN_METHOD(publish:
                   callback:(RCTResponseSenderBlock*)callback)
 RCT_EXTERN_METHOD(subscribeToStream:
                   (NSString*)streamId
+                  sessionId:
                   (NSString*)sessionId
                   properties:(NSDictionary*)properties
                   callback:(RCTResponseSenderBlock*)callback)

--- a/ios/OpenTokReactNative/OTSessionManager.m
+++ b/ios/OpenTokReactNative/OTSessionManager.m
@@ -31,6 +31,7 @@ RCT_EXTERN_METHOD(publish:
                   callback:(RCTResponseSenderBlock*)callback)
 RCT_EXTERN_METHOD(subscribeToStream:
                   (NSString*)streamId
+                  (NSString*)sessionId
                   properties:(NSDictionary*)properties
                   callback:(RCTResponseSenderBlock*)callback)
 RCT_EXTERN_METHOD(removeSubscriber:

--- a/ios/OpenTokReactNative/OTSessionManager.swift
+++ b/ios/OpenTokReactNative/OTSessionManager.swift
@@ -120,7 +120,7 @@ class OTSessionManager: RCTEventEmitter {
         }
     }
     
-    @objc func subscribeToStream(_ streamId: String, properties: Dictionary<String, Any>, callback: @escaping RCTResponseSenderBlock) -> Void {
+    @objc func subscribeToStream(_ streamId: String, sessionId: String, properties: Dictionary<String, Any>, callback: @escaping RCTResponseSenderBlock) -> Void {
         var error: OTError?
         DispatchQueue.main.async {
             guard let stream = OTRN.sharedState.subscriberStreams[streamId] else {
@@ -133,7 +133,7 @@ class OTSessionManager: RCTEventEmitter {
                 callback([errorInfo]);
                 return
             }
-            guard let session = OTRN.sharedState.sessions[stream.session.sessionId] else {
+            guard let session = OTRN.sharedState.sessions[sessionId] else {
                 let errorInfo = EventUtils.createErrorMessage("Error subscribing to stream. Could not find native session instance")
                 callback([errorInfo]);
                 return

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-react-native",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-react-native",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3504,7 +3504,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3525,12 +3526,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3545,17 +3548,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3672,7 +3678,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3684,6 +3691,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3698,6 +3706,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3705,12 +3714,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3729,6 +3740,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3809,7 +3821,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3821,6 +3834,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3906,7 +3920,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3942,6 +3957,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3961,6 +3977,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4004,12 +4021,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-react-native",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "React Native components for OpenTok iOS and Android SDKs",
   "main": "src/index.js",
   "homepage": "https://www.tokbox.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-react-native",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "React Native components for OpenTok iOS and Android SDKs",
   "main": "src/index.js",
   "homepage": "https://www.tokbox.com",

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -57,13 +57,13 @@ export default class OTSubscriber extends Component {
   streamCreatedHandler = (stream) => {
     const { subscribeToSelf } = this.state;
     const { streamProperties, properties } = this.props;
-    const { sessionInfo } = this.context;
+    const { sessionId, sessionInfo } = this.context;
     const subscriberProperties = isNull(streamProperties[stream.streamId]) ?
                                   sanitizeProperties(properties) : sanitizeProperties(streamProperties[stream.streamId]);
     // Subscribe to streams. If subscribeToSelf is true, subscribe also to his own stream
     const sessionInfoConnectionId = sessionInfo && sessionInfo.connection ? sessionInfo.connection.connectionId : null;
     if (subscribeToSelf || (sessionInfoConnectionId !== stream.connectionId)){
-      OT.subscribeToStream(stream.streamId, subscriberProperties, (error) => {
+      OT.subscribeToStream(stream.streamId, sessionId, subscriberProperties, (error) => {
         if (error) {
           this.otrnEventHandler(error);
         } else {


### PR DESCRIPTION
Based on https://tokbox.com/developer/sdks/android/release-notes.html, I had to edit the subscribeToStream method to get sessionId as input from the React Component (as stream.getSession has been deprecated).

**Android:**

- edited EventUtils.js to accept Session object as input.
- subscribeToStream method: added sessionId as input from the React method
- OTPublisherView.java is failing because publisher.getSession has sessionId null. I am still investigating the issue, it could be a bug on the 2.17.0 SDK.

**iOS:**

- subscribeToStream method: added sessionId as input. Even if not needed, I thought it could be nice to have the same method signature between iOS and Android
- iOS needs testing